### PR TITLE
Updated dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [
           {name: "Ubuntu", os: "ubuntu-latest", shell: "bash", compiler: "g++"},
-          {name: "MacOS 12", os: "macos-12", shell: "bash", compiler: "g++-12"},
+          {name: "MacOS 13", os: "macos-13", shell: "bash", compiler: "g++-12"},
           {name: "MacOS 14 (M1)", os: "macos-14", shell: "bash", compiler: "g++-13"},
           {name: "Windows", os: "windows-latest", shell: "msys2", compiler: "g++"},
         ]
@@ -32,6 +32,9 @@ jobs:
           {project: "custom-division-sample", name: "PhysiCell custom division", binary: "project", config: "config/PhysiCell_settings.xml", max_time: 120, output_folder: ""},
           {project: "interaction-sample", name: "PhysiCell interactions", binary: "interaction_demo", config: "config/PhysiCell_settings.xml", max_time: 120, output_folder: ""},
           {project: "pred-prey-farmer", name: "PhysiCell prey predator", binary: "pred_prey", config: "config/PhysiCell_settings.xml", max_time: 120, output_folder: ""},
+          {project: "ecoli-acetic-switch-sample", name: "PhysiCell Ecoli Acetic Switch", binary: "ecoli-dfba", config: "config/PhysiCell_settings.xml", max_time: 120, output_folder: ""},
+          {project: "ecoli-acetic-switch-sample", name: "PhysiCell Ecoli Acetic Switch", binary: "ecoli-dfba", config: "config/Ecoli_core.xml", max_time: 120, output_folder: ""},
+          {project: "ecoli-acetic-switch-sample", name: "PhysiCell Ecoli Acetic Switch", binary: "ecoli-dfba", config: "config/Ecoli_static_ox_glc.xml", max_time: 120, output_folder: ""},
         ]
         
     name: Testing ${{ matrix.projects.name }} on ${{ matrix.os.name }}

--- a/addons/PhysiBoSS/src/maboss_intracellular.h
+++ b/addons/PhysiBoSS/src/maboss_intracellular.h
@@ -127,6 +127,8 @@ class MaBoSSIntracellular : public PhysiCell::Intracellular {
     int validate_PhysiCell_tokens(PhysiCell::Phenotype& phenotype) {return 0; }
     int validate_SBML_species() {return 0; }
     int create_custom_data_for_SBML(PhysiCell::Phenotype& phenotype) {return 0; }
+	double get_flux_value(std::string name) {return 0.0;}
+	double get_growth_rate() {return 0.0;}
 
 };
 

--- a/beta/fba_packages.json
+++ b/beta/fba_packages.json
@@ -4,37 +4,47 @@
         "_refurl": "https://www.coin-or.org/download/binary/Clp/",
         "linux-x64": 
         {
-            "version": "Clp-1.17.6-linux64.zip",
-            "url": "https://maboss.curie.fr/pub/Clp-1.17.6-linux64.zip"
+            "version": "Clp-releases.1.17.10-x86_64-ubuntu20-gcc940-static.tar.gz",
+            "url": "https://github.com/coin-or/Clp/releases/download/releases%2F1.17.10/Clp-releases.1.17.10-x86_64-ubuntu20-gcc940-static.tar.gz"
         },
         "win64": 
         {
-            "version": "Clp-1.17.6-win64.zip",
-            "url": "https://maboss.curie.fr/pub/Clp-1.17.6-win64.zip"
+            "version": "Clp-releases.1.17.10-x86_64-w64-mingw64.zip",
+            "url": "https://github.com/coin-or/Clp/releases/download/releases%2F1.17.10/Clp-releases.1.17.10-x86_64-w64-mingw64.zip"
         },
-        "osx":
+        "osx-arm64":
         {
-            "version": "Clp-1.17.6-osx64.zip",
-            "url": "https://maboss.curie.fr/pub/Clp-1.17.6-osx64.zip"
+            "version": "Clp-releases.1.17.10-arm64-macos14-gcc1330.tar.gz",
+            "url": "https://github.com/coin-or/Clp/releases/download/releases%2F1.17.10/Clp-releases.1.17.10-arm64-macos14-gcc1330.tar.gz"
+        },
+        "osx-x86_64":
+        {
+            "version": "Clp-releases.1.17.10-x86_64-macos13-gcc1330.tar.gz",
+            "url": "https://github.com/coin-or/Clp/releases/download/releases%2F1.17.10/Clp-releases.1.17.10-x86_64-macos13-gcc1330.tar.gz"
         }
     },
     "libsbml": 
     {
-        "_refurl": "https://sourceforge.net/projects/sbml/files/libsbml/5.14.0-experimental/binaries/",
+        "_refurl": "http://maboss.curie.fr/pub/",
         "linux-x64": 
         {
-            "version": "libSBML-5.19.0-linux64.zip",
-            "url": "https://maboss.curie.fr/pub/libSBML-5.19.0-linux64.zip"
+            "version": "libSBML-5.20.4-linux64.zip",
+            "url": "http://maboss.curie.fr/pub/libSBML-5.20.4-linux64.zip"
         },
         "win64": 
         {
-            "version": "libSBML-5.19.0-win64.zip",
-            "url": "https://maboss.curie.fr/pub/libSBML-5.19.0-win64.zip"
+            "version": "libSBML-5.20.4-win64.zip",
+            "url": "http://maboss.curie.fr/pub/libSBML-5.20.4-win64.zip"
         },
-        "osx":
+        "osx-x86_64":
         {
-            "version": "libSBML-5.19.0-osx64.zip",
-            "url": "https://maboss.curie.fr/pub/libSBML-5.19.0-osx64.zip"
+            "version": "libSBML-5.20.4-osx-x86_64.zip",
+            "url": "http://maboss.curie.fr/pub/libSBML-5.20.4-osx-x86_64.zip"
+        },
+        "osx-arm64":
+        {
+            "version": "libSBML-5.20.4-osx-arm64.zip",
+            "url": "http://maboss.curie.fr/pub/libSBML-5.20.4-osx-arm64.zip"
         }
     }
 }

--- a/beta/setup_fba.py
+++ b/beta/setup_fba.py
@@ -17,7 +17,12 @@ def get_os_arch():
     if os_type == 'linux':
         return 'linux-x64' if arch in ('x86_64', 'amd64') else 'linux-x86'
     elif os_type == 'darwin':
-        return 'osx'
+        if arch == 'arm64':
+            return 'osx-arm64'
+        elif arch == 'x86_64':
+            return 'osx-x86_64'
+        print(f"Unsupported architecture: {os_type} : {arch}")
+        sys.exit(1)
     elif os_type.startswith('win'):
         return 'win64' if arch == 'amd64' else 'win32'
     else:

--- a/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
+++ b/sample_projects_intracellular/fba/ecoli_acetic_switch/Makefile
@@ -13,7 +13,7 @@ CUR_DIR = $(shell pwd)
 EXT_DIR = $(CUR_DIR)/addons/dFBA/ext
 
 
-LIB := -L$(EXT_DIR)/libsbml/lib -L$(EXT_DIR)/coin-or/lib/ -lClp-static -lCoinUtils-static -llapack -lsbml-static -lxml2 -lbz2 -lz
+LIB := -L$(EXT_DIR)/libsbml/lib -L$(EXT_DIR)/coin-or/lib/ -lClp -lCoinUtils -llapack -lsbml-static -lxml2 -lbz2 -lz -ggdb
 INC := -DADDON_PHYSIDFBA -I$(EXT_DIR)/libsbml/include -I$(EXT_DIR)/coin-or/include -I$(CUR_DIR)/addons/dFBA/src
 
 


### PR DESCRIPTION
Here are the updated dependencies install: 
- Makefile now needs to have deps installed before trying to compile
- Clp now using latest release from github, libSBML using latest version, with binaries produced by me. 

I haven't tested outside of linux yet, where it compiles and run. It should work for M1 mac, but not the old ones. 